### PR TITLE
Feature buildInfo

### DIFF
--- a/doveadm_wrapper/main.go
+++ b/doveadm_wrapper/main.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"strings"
 	"syscall"
 )
 
+const version = "0.1.1"
 const allowedEmail = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.@"
 const allowedPassword = "0123456789abcdef"
 
@@ -31,6 +33,27 @@ func errorHandler(err error) {
 }
 
 func main() {
+	if os.Args[1] == "--version" {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if !ok {
+			panic("Can't read BuildInfo")
+		}
+
+		fmt.Printf("pwch version: %s\n", version)
+		fmt.Println("Built with:")
+		fmt.Printf("  %s\n", buildInfo.GoVersion)
+
+		fmt.Println("Dependencies:")
+		if len(buildInfo.Deps) > 0 {
+			for _, dep := range buildInfo.Deps {
+				fmt.Printf("  %s %s\n", dep.Path, dep.Version)
+			}
+		} else {
+			fmt.Println("  no external dependencies")
+		}
+		os.Exit(0)
+	}
+
 	if os.Args[1] != "" {
 		behavior := os.Args[1]
 

--- a/pwch/main.go
+++ b/pwch/main.go
@@ -13,6 +13,7 @@ import (
 	"net/smtp"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const version = "0.1.1"
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 const lowercase = "abcdefghijklmnopqrstuvwxyz"
 const uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -461,6 +463,27 @@ func passwordSubmitHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	if os.Args[1] == "--version" {
+		buildInfo, ok := debug.ReadBuildInfo()
+		if !ok {
+			panic("Can't read BuildInfo")
+		}
+
+		fmt.Printf("pwch version: %s\n", version)
+		fmt.Println("Built with:")
+		fmt.Printf("  %s\n", buildInfo.GoVersion)
+
+		fmt.Println("Dependencies:")
+		if len(buildInfo.Deps) > 0 {
+			for _, dep := range buildInfo.Deps {
+				fmt.Printf("  %s %s\n", dep.Path, dep.Version)
+			}
+		} else {
+			fmt.Println("  no external dependencies")
+		}
+		os.Exit(0)
+	}
+
 	readFile(&cfg)
 
 	rand.Seed(time.Now().UnixNano())
@@ -473,7 +496,7 @@ func main() {
 	mux.HandleFunc(cfg.URLPrefix+"/changePassword", passwordChangeHandler)
 	mux.HandleFunc(cfg.URLPrefix+"/submitPassword", passwordSubmitHandler)
 
-	log.Print("pwch 0.1.1")
+	log.Printf("pwch %s", version)
 	log.Print("INFO: Listening on " + cfg.Server.ListenAddress + ":" + cfg.Server.Port)
 	go func() {
 		log.Fatal(http.ListenAndServe(cfg.Server.ListenAddress+":"+cfg.Server.Port, mux))


### PR DESCRIPTION
This feature prints some version information when running the compiled binaries with the `--version` flag.

Printed info includes:

* pwch version
* go version used to compile
* external dependencies (path and version)

Here is an example:

```
$ ./pwch --version
pwch version: 0.2.0
Built with:
  go1.19.7
Dependencies:
  github.com/lib/pq v1.10.7
  golang.org/x/crypto v0.7.0
  gopkg.in/yaml.v2 v2.4.0
```
