### PR TITLE
Let pwch listen on unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pwch will handle all subsequent reencryptions during a password change.
 Despite significant efforts to secure the application, there is a potential
 vulnerability when calling the doveadm binary to reencrypt mailboxes.
 This vulnerability arises when local attackers possess root permissions
-and the requisite knowledge to intercept passwords that are written via stdin
+and the required knowledge to intercept passwords that are written via stdin
 to the doveadm command.
 It is essential to recognize that the only truly secure method of
 storing emails confidentially is through end-to-end encryption.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ You'll have to initially encrypt mailboxes for your users manually
 
 pwch will handle all subsequent reencryptions during a password change.
 
+### A note on security
+
+Despite significant efforts to secure the application, there is a potential
+vulnerability when calling the doveadm binary to reencrypt mailboxes.
+This vulnerability arises when local attackers possess root permissions
+and the requisite knowledge to intercept passwords that are written via stdin
+to the doveadm command.
+It is essential to recognize that the only truly secure method of
+storing emails confidentially is through end-to-end encryption.
+
 -----
 
 ## What it does

--- a/cmd/pwch/main.go
+++ b/cmd/pwch/main.go
@@ -647,7 +647,9 @@ func main() {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		os.Remove(cfg.Server.SocketPath)
+		if err := os.Remove(cfg.Server.SocketPath); err != nil {
+			log.Fatal(err)
+		}
 		os.Exit(0)
 	}()
 

--- a/cmd/pwch/main.go
+++ b/cmd/pwch/main.go
@@ -26,14 +26,17 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"net"
 	"net/http"
 	"net/mail"
 	"net/smtp"
 	"os"
 	"os/exec"
+	"os/signal"
 	"runtime/debug"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unicode"
 
@@ -53,8 +56,7 @@ type config struct {
 	URLPrefix  string `yaml:"url_prefix"`
 	AssetsPath string `yaml:"assets_path"`
 	Server     struct {
-		ListenAddress string `yaml:"listen_address"`
-		Port          string `yaml:"port"`
+		SocketPath string `yaml:"socket_path"`
 	} `yaml:"server"`
 	DB struct {
 		Host     string `yaml:"host"`
@@ -635,17 +637,30 @@ func main() {
 	mux.HandleFunc(cfg.URLPrefix+"/changePassword", passwordChangeHandler)
 	mux.HandleFunc(cfg.URLPrefix+"/submitPassword", passwordSubmitHandler)
 
-	srv := &http.Server{
-		Addr:         cfg.Server.ListenAddress + ":" + cfg.Server.Port,
+	socket, err := net.Listen("unix", cfg.Server.SocketPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Cleanup the sockfile.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-c
+		os.Remove(cfg.Server.SocketPath)
+		os.Exit(0)
+	}()
+
+	server := http.Server{
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}
 
 	log.Printf("pwch %s", version)
-	log.Print("INFO: Listening on " + cfg.Server.ListenAddress + ":" + cfg.Server.Port)
+	log.Print("INFO: Listening on " + cfg.Server.SocketPath)
 	go func() {
-		log.Fatal(srv.ListenAndServe())
+		log.Fatal(server.Serve(socket))
 	}()
 
 	ticker := time.NewTicker(30 * time.Second)

--- a/config/config.yml
+++ b/config/config.yml
@@ -4,8 +4,7 @@ url_prefix: /selfservice
 assets_path: /usr/local/src/pwch
 
 server:
-  listen_address: 127.0.0.1
-  port: 8080
+  socket_path: /run/pwch/pwch.sock
 
 db:
   host: /run/postgresql


### PR DESCRIPTION
This feature introduces a breaking change. pwch will no longer listen on an IP socket but instead do so on an Unix socket.

-----

__Doesn't that complicate things for my use case?__

Transitioning exclusively to Unix sockets instead of IP sockets doesn't complicate pwch usage, since it has been designed for deployment behind a reverse proxy all along.

__Why the change then?__

pwch itself doesn't have the capability to obtain TLS certificates itself. Therefore I think it's a risk to even create the possibility to let pwch listen on public networks.

Additionally, snooping on Unix sockets is harder than on loopback IP since they operate solely within the kernel, confining local communication. Loopback IP goes through the network stack, allowing potential interception.

After all, this is an attempt to further harden the application against potential password snooping.

